### PR TITLE
Added 'CI=true' variable to Dockerfile so that pnpm build succeeds inside Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ COPY web/package.json web/pnpm-lock.yaml* ./web/
 COPY . .
 RUN sed -i 's|$(EMSDK_ENV) --build=Release && emcc|emcc|g' Makefile
 RUN mkdir -p /app/firmware/stock
+ENV CI=true
 RUN make all
 
 FROM nginx:1.28.0-alpine


### PR DESCRIPTION
When I first tried to build the project using `docker compose up -d`, the build failed and gave the following error message:

```
12.31 cd web && pnpm install && pnpm build
13.17  ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY  Aborted removal of modules directory due to no TTY
13.17
13.17 If you are running pnpm in CI, set the CI environment variable to "true".
13.22 make: *** [Makefile:70: web] Error 1
```

I simply did as instructed and added `ENV CI=true` to the Dockerfile, now the build succeeds.
Not sure if this error occurred before for other people, I am on macOS arm64 in case this matters.

Just wanted to contribute this simple fix so that it hopefully works out of the box for the next person trying this. I think its cool to have the local Docker version not only if the website should go down but also if we desperately need to upload new custom modes in a mountain cabin with no wifi for some reason ;-)